### PR TITLE
Space Key Error For Linux

### DIFF
--- a/keyboard_control.py
+++ b/keyboard_control.py
@@ -50,10 +50,10 @@ class KeyboardDrone:
         if key.char == 'c':
             self.mc.start_down(self.velocity)
 
-        if key == keyboard.Key.space:
+        if key.char == 'v':
             self.mc.start_up(self.velocity)
 
-        if key.char == 'l':
+        if key.char == 'k':
             print('Kill engines')
             return False
 


### PR DESCRIPTION
Space key gives error for Linux. Also Kill Engine's abbreviation 'k' is more compatible